### PR TITLE
🔧 Fix Laravel detection logic and installation step order

### DIFF
--- a/installer/includes/error_handler.php
+++ b/installer/includes/error_handler.php
@@ -150,7 +150,7 @@ class ErrorHandler {
             $backendPath = dirname(__DIR__, 2) . '/backend';
             if (file_exists($backendPath . '/artisan')) {
                 $output = PHPUtils::execArtisan("--version", $backendPath);
-                if (strpos($output, 'Laravel') !== false) {
+                if (strpos($output, 'Laravel Framework') !== false || strpos($output, 'Laravel') !== false) {
                     $results['laravel'] = ['status' => 'PASS', 'message' => trim($output)];
                 } else {
                     $results['laravel'] = ['status' => 'FAIL', 'message' => 'Laravel not responding properly'];

--- a/installer/install.php
+++ b/installer/install.php
@@ -226,18 +226,17 @@ VITE_PUSHER_APP_CLUSTER=\"\${PUSHER_APP_CLUSTER}\"
                 $this->log("✅ Laravel dependencies already installed");
             }
             
-            // Clear all caches
+            // Clear config and route caches (safe to do before migrations)
             $this->runArtisanCommand("config:clear", "Config cache cleared");
             $this->runArtisanCommand("route:clear", "Route cache cleared");
             $this->runArtisanCommand("view:clear", "View cache cleared");
-            $this->runArtisanCommand("cache:clear", "Application cache cleared");
             
             // Generate application key
             $this->runArtisanCommand("key:generate --force", "Application key generated");
             
             // Test Laravel
             $output = $this->runArtisanCommand("--version", "Laravel version check", false);
-            if (!strpos($output, 'Laravel')) {
+            if (strpos($output, 'Laravel Framework') === false && strpos($output, 'Laravel') === false) {
                 throw new Exception("Laravel not working properly. Output: " . $output);
             }
             
@@ -266,6 +265,15 @@ VITE_PUSHER_APP_CLUSTER=\"\${PUSHER_APP_CLUSTER}\"
             }
             
             $this->log("✅ Database migrations completed");
+            
+            // Now safe to clear application cache (after database tables exist)
+            try {
+                $this->runArtisanCommand("cache:clear", "Application cache cleared", false);
+                $this->log("✅ Application cache cleared");
+            } catch (Exception $e) {
+                $this->log("⚠️ Cache clear warning: " . $e->getMessage());
+                // Don't fail installation for cache issues
+            }
             
         } catch (Exception $e) {
             throw new Exception("Migration failed: " . $e->getMessage());

--- a/optimize_platform.php
+++ b/optimize_platform.php
@@ -120,7 +120,7 @@ try {
     if (file_exists($backendPath . '/artisan')) {
         try {
             $output = PHPUtils::execArtisan("--version", $backendPath);
-            if (strpos($output, 'Laravel') !== false) {
+            if (strpos($output, 'Laravel Framework') !== false || strpos($output, 'Laravel') !== false) {
                 echo "<p class='success'>✅ Laravel working: " . htmlspecialchars(trim($output)) . "</p>";
                 $optimizations[] = "Laravel functionality verified";
             } else {

--- a/test_system.php
+++ b/test_system.php
@@ -100,7 +100,7 @@ runTest("Laravel Configuration", function() {
     try {
         // Test artisan with proper PHP path
         $output = PHPUtils::execArtisan("--version", $backendPath);
-        if (!strpos($output, 'Laravel')) {
+        if (strpos($output, 'Laravel Framework') === false && strpos($output, 'Laravel') === false) {
             return "Laravel not working: " . $output;
         }
         


### PR DESCRIPTION
- Fix Laravel version detection to handle 'Laravel Framework 12.22.1' output
- Reorder installation steps: run migrations before cache operations
- Move cache:clear after migrations to avoid 'table doesn't exist' errors
- Update all Laravel detection logic across installer, test system, and utilities
- Add proper error handling for cache operations

This fixes the false failure when Laravel Framework is properly detected and prevents cache errors when database tables don't exist yet.